### PR TITLE
Fix for std.code.maintindex.simple

### DIFF
--- a/ext/std/tools/test.py
+++ b/ext/std/tools/test.py
@@ -10,6 +10,7 @@ import mpp.api
 import subprocess
 import os.path
 import itertools
+import sys
 
 class Plugin(mpp.api.Plugin, mpp.api.IConfigurable, mpp.api.IRunable):
     
@@ -27,7 +28,7 @@ class Plugin(mpp.api.Plugin, mpp.api.IConfigurable, mpp.api.IRunable):
         os.environ['METRIXPLUSPLUS_TEST_MODE'] = str("True")
         
         tests_dir = os.path.join(os.environ['METRIXPLUSPLUS_INSTALL_DIR'], 'tests')
-        process_data= ["python", "-m", "unittest", "discover", "-v", "-s"]
+        process_data= [sys.executable, "-m", "unittest", "discover", "-v", "-s"]
         if len(args) == 0 or tests_dir == os.path.abspath(args[0]):
             for fname in sorted(os.listdir(tests_dir)):
                 full_path = os.path.join(tests_dir, fname)

--- a/mpp/api.py
+++ b/mpp/api.py
@@ -1154,13 +1154,15 @@ class MetricPluginMixin(Parent):
         
         def get_result(self):
             sourced_metric = self.region.get_data(self.rank_source[0], self.rank_source[1])
-            if sourced_metric != None:
-                for (ind, range_pair) in enumerate(self.rank_ranges):
-                    if ((range_pair[0] == None or sourced_metric >= range_pair[0])
-                        and
-                        (range_pair[1] == None or sourced_metric <= range_pair[1])):
-                        self.result = self.result * (ind + 1)
-                        break
+            if sourced_metric == None:
+                assert(self.region.get_type() == Region.T.GLOBAL);
+                return None;
+            for (ind, range_pair) in enumerate(self.rank_ranges):
+                if ((range_pair[0] == None or sourced_metric >= range_pair[0])
+                    and
+                    (range_pair[1] == None or sourced_metric <= range_pair[1])):
+                    self.result = self.result * (ind + 1)
+                    break
             return self.result
 
     def declare_metric(self, is_active, field,

--- a/mpp/api.py
+++ b/mpp/api.py
@@ -1154,10 +1154,11 @@ class MetricPluginMixin(Parent):
         
         def get_result(self):
             sourced_metric = self.region.get_data(self.rank_source[0], self.rank_source[1])
-            for (ind, range_pair) in enumerate(self.rank_ranges):
-                if ((range_pair[0] == None or sourced_metric >= range_pair[0])
-                    and
-                    (range_pair[1] == None or sourced_metric <= range_pair[1])):
+            if sourced_metric != None:
+                for (ind, range_pair) in enumerate(self.rank_ranges):
+                    if ((range_pair[0] == None or sourced_metric >= range_pair[0])
+                        and
+                        (range_pair[1] == None or sourced_metric <= range_pair[1])):
                         self.result = self.result * (ind + 1)
                         break
             return self.result

--- a/mpp/api.py
+++ b/mpp/api.py
@@ -1154,8 +1154,10 @@ class MetricPluginMixin(Parent):
         
         def get_result(self):
             sourced_metric = self.region.get_data(self.rank_source[0], self.rank_source[1])
+            # necessary with python3
             if sourced_metric == None:
-                assert(self.region.get_type() == Region.T.GLOBAL);
+                assert(self.region.get_type() != Region.T.FUNCTION);
+                assert(self.rank_source == ('std.code.complexity', 'cyclomatic'));
                 return None;
             for (ind, range_pair) in enumerate(self.rank_ranges):
                 if ((range_pair[0] == None or sourced_metric >= range_pair[0])

--- a/tests/common.py
+++ b/tests/common.py
@@ -13,6 +13,7 @@ import difflib
 import unittest
 import shutil
 import ast
+import sys
 
 class ToolRunner(object):
 
@@ -62,8 +63,8 @@ class ToolRunner(object):
         if dirs_list != None:
             for each in dirs_list:
                 self.dirs_list.append(each)
-               
-        self.call_args = ['python', os.path.join(os.environ['METRIXPLUSPLUS_INSTALL_DIR'], "metrix++.py"), tool_name] \
+
+        self.call_args = [sys.executable, os.path.join(os.environ['METRIXPLUSPLUS_INSTALL_DIR'], "metrix++.py"), tool_name] \
                     + db_opts + opts_list + ['--'] + self.dirs_list
         self.cmd = " ".join(self.call_args)
         self.exit_code_expected = exit_code

--- a/tests/general/test_basic.py
+++ b/tests/general/test_basic.py
@@ -367,5 +367,17 @@ class Test(tests.common.TestCase):
         runner = tests.common.ToolRunner('view', ['--format=txt'], prefix='txt')
         self.assertExec(runner.run())
 
+    def test_std_maintindex(self):
+        runner = tests.common.ToolRunner('collect',
+                                         ['--std.code.complexity.cyclomatic',
+                                          '--std.code.lines.code',
+                                          '--std.code.maintindex.simple',
+                                          '--log-level=INFO'],
+                                         check_stderr=[(0, -1)],
+                                         save_prev=True)
+        self.assertExec(runner.run())
+        runner = tests.common.ToolRunner('view', ['--format=txt'], prefix='txt')
+        self.assertExec(runner.run())
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/general/test_basic/test_std_maintindex_collect_default_stderr.gold.txt
+++ b/tests/general/test_basic/test_std_maintindex_collect_default_stderr.gold.txt
@@ -1,0 +1,6 @@
+[LOG]: WARNING:	Logging enabled with INFO level
+[LOG]: INFO:	Excluding: ./.unused.cpp
+[LOG]: INFO:	Skipping: ./dummy.txt
+[LOG]: INFO:	Processing: ./file_deleted_in_new_sources.cpp
+[LOG]: INFO:	Processing: ./simple.cpp
+[LOG]: WARNING:	Done (1 seconds). Exit code: 0

--- a/tests/general/test_basic/test_std_maintindex_view_txt_stdout.gold.txt
+++ b/tests/general/test_basic/test_std_maintindex_view_txt_stdout.gold.txt
@@ -1,0 +1,40 @@
+./:: info: Overall metrics for 'std.code.complexity:cyclomatic' metric
+	Average        : 1.375
+	Minimum        : 1
+	Maximum        : 3
+	Total          : 11.0
+	Distribution   : 8 regions in total (including 0 suppressed)
+	  Metric value : Ratio : R-sum : Number of regions
+	             1 : 0.750 : 0.750 : 6	|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+	             2 : 0.125 : 0.875 : 1	||||||||||||
+	             3 : 0.125 : 1.000 : 1	||||||||||||
+
+./:: info: Overall metrics for 'std.code.lines:code' metric
+	Average        : 4.875
+	Minimum        : 0
+	Maximum        : 11
+	Total          : 78.0
+	Distribution   : 16 regions in total (including 0 suppressed)
+	  Metric value : Ratio : R-sum : Number of regions
+	             0 : 0.125 : 0.125 :  2	||||||||||||
+	             3 : 0.188 : 0.312 :  3	||||||||||||||||||
+	             4 : 0.188 : 0.500 :  3	||||||||||||||||||
+	             5 : 0.125 : 0.625 :  2	||||||||||||
+	             7 : 0.250 : 0.875 :  4	|||||||||||||||||||||||||
+	             8 : 0.062 : 0.938 :  1	||||||
+	            11 : 0.062 : 1.000 :  1	||||||
+
+./:: info: Overall metrics for 'std.code.mi:simple' metric
+	Average        : 1.0
+	Minimum        : 1
+	Maximum        : 1
+	Total          : 16.0
+	Distribution   : 16 regions in total (including 0 suppressed)
+	  Metric value : Ratio : R-sum : Number of regions
+	             1 : 1.000 : 1.000 : 16	||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
+./:: info: Directory content:
+	File           : file_deleted_in_new_sources.cpp
+	File           : simple.cpp
+
+


### PR DESCRIPTION
This PR addresses #13. In the case of the global region, there is no cyclomatic complexity, and `sourced_metric` is None, which cannot be compared to an integer. 