### PR TITLE
Exclude multiple comma separated files with --ef

### DIFF
--- a/metrixpp/ext/std/tools/collect.py
+++ b/metrixpp/ext/std/tools/collect.py
@@ -51,7 +51,10 @@ class Plugin(api.Plugin, api.Parent, api.IConfigurable, api.IRunable):
         except Exception as e:
             self.optparser.error("option --include-files: " + str(e))
         try:
-            self.add_exclude_rule(re.compile(options.__dict__['exclude_files']))
+            input_arg = options.__dict__['exclude_files']
+            files = input_arg.split(',')
+            for each in files:
+                self.add_exclude_rule(re.compile(each))
         except Exception as e:
             self.optparser.error("option --exclude-files: " + str(e))
         self.non_recursively = options.__dict__['non_recursively']


### PR DESCRIPTION
Multiple files/folders can be excluded by using the collect command with the following tag
--ef=main1.c,main2.c,src