### PR TITLE
Bug fix --ef issue

### DIFF
--- a/metrixpp/ext/std/tools/collect.py
+++ b/metrixpp/ext/std/tools/collect.py
@@ -51,7 +51,7 @@ class Plugin(api.Plugin, api.Parent, api.IConfigurable, api.IRunable):
         except Exception as e:
             self.optparser.error("option --include-files: " + str(e))
         try:
-            self.add_exclude_rule(re.compile(options.__dict__['exclude_files']))
+            self.add_exclude_rule(re.compile('^' + options.__dict__['exclude_files'] + '$'))
         except Exception as e:
             self.optparser.error("option --exclude-files: " + str(e))
         self.non_recursively = options.__dict__['non_recursively']


### PR DESCRIPTION
Lets say the directory has 2 folders named **src** and **src_1**. Now if --ef tag is used to exclude folder **src**, then **src_1** also gets excluded which is not desirable. This PR fixes this bug. 