### PR TITLE
Add new linelength plugin

### DIFF
--- a/metrixpp/ext/std/code/linelength.ini
+++ b/metrixpp/ext/std/code/linelength.ini
@@ -1,0 +1,15 @@
+;
+;    Metrix++, Copyright 2009-2019, Metrix++ Project
+;    Link: https://github.com/metrixplusplus/metrixplusplus
+;
+;    This file is a part of Metrix++ Tool.
+;
+
+[Plugin]
+version: 1.0
+package: std.code
+module:  linelength
+class:   Plugin
+depends: None
+actions: collect
+enabled: True

--- a/metrixpp/ext/std/code/linelength.py
+++ b/metrixpp/ext/std/code/linelength.py
@@ -1,0 +1,42 @@
+#
+#    Metrix++, Copyright 2009-2019, Metrix++ Project
+#    Link: https://github.com/metrixplusplus/metrixplusplus
+#
+#    This file is a part of Metrix++ Tool.
+#
+
+from metrixpp.mpp import api
+import re
+
+class Plugin(api.Plugin,
+             api.IConfigurable,
+             api.Child,
+             api.MetricPluginMixin):
+
+    def declare_configuration(self, parser):
+        parser.add_option("--std.code.linelength", "--scll",
+            action="store_true", default=False,
+            help="Enables collection maximum line-length transgressions [default: %default]")
+        parser.add_option("--std.code.linelength.limit", "--sclll",
+            default=80,
+            help="Modifies the limit for maximum line-length [default: %default]")
+
+    def configure(self, options):
+        self.is_active_ll = options.__dict__['std.code.linelength']
+        self.threshold = int(options.__dict__['std.code.linelength.limit'])
+
+    def initialize(self):
+        pattern_to_search = r'''.{%s,}''' % (self.threshold + 1)
+        self.declare_metric(
+                self.is_active_ll,
+                self.Field('numbers', int),
+                re.compile(pattern_to_search),
+                marker_type_mask=api.Marker.T.CODE,
+                region_type_mask=api.Region.T.ANY,
+                exclude_subregions=True)
+
+        super(Plugin, self).initialize(fields=self.get_fields())
+
+        if self.is_active_ll == True:
+            self.subscribe_by_parents_interface(api.ICode)
+

--- a/metrixpp/ext/std/code/linelength.py
+++ b/metrixpp/ext/std/code/linelength.py
@@ -16,7 +16,7 @@ class Plugin(api.Plugin,
     def declare_configuration(self, parser):
         parser.add_option("--std.code.linelength", "--scll",
             action="store_true", default=False,
-            help="Enables collection maximum line-length transgressions [default: %default]")
+            help="Enables collection of maximum line-length overruns [default: %default]")
         parser.add_option("--std.code.linelength.limit", "--sclll",
             default=80,
             help="Modifies the limit for maximum line-length [default: %default]")

--- a/metrixpp/ext/std/code/longlines.ini
+++ b/metrixpp/ext/std/code/longlines.ini
@@ -8,7 +8,7 @@
 [Plugin]
 version: 1.0
 package: std.code
-module:  linelength
+module:  longlines
 class:   Plugin
 depends: None
 actions: collect

--- a/metrixpp/ext/std/code/longlines.py
+++ b/metrixpp/ext/std/code/longlines.py
@@ -14,16 +14,16 @@ class Plugin(api.Plugin,
              api.MetricPluginMixin):
 
     def declare_configuration(self, parser):
-        parser.add_option("--std.code.linelength", "--scll",
+        parser.add_option("--std.code.longlines", "--scll",
             action="store_true", default=False,
-            help="Enables collection of maximum line-length overruns [default: %default]")
-        parser.add_option("--std.code.linelength.limit", "--sclll",
+            help="Enables collection of long lines metric [default: %default]")
+        parser.add_option("--std.code.longlines.limit", "--sclll",
             default=80,
             help="Modifies the limit for maximum line-length [default: %default]")
 
     def configure(self, options):
-        self.is_active_ll = options.__dict__['std.code.linelength']
-        self.threshold = int(options.__dict__['std.code.linelength.limit'])
+        self.is_active_ll = options.__dict__['std.code.longlines']
+        self.threshold = int(options.__dict__['std.code.longlines.limit'])
 
     def initialize(self):
         pattern_to_search = r'''.{%s,}''' % (self.threshold + 1)

--- a/metrixpp/tests/general/test_basic.py
+++ b/metrixpp/tests/general/test_basic.py
@@ -300,6 +300,21 @@ class Test(tests.common.TestCase):
         runner = tests.common.ToolRunner('view', ['--format=txt'], prefix='txt')
         self.assertExec(runner.run())
 
+    def test_std_longlines_metrics(self):
+
+        runner = tests.common.ToolRunner('collect',
+                                         ['--std.code.longlines',
+                                          '--std.code.longlines.limit=50'])
+        self.assertExec(runner.run())
+
+        runner = tests.common.ToolRunner('view',
+                                         ['--nest-regions', '--format=txt'],
+                                         prefix='nest_per_file',
+                                         dirs_list=['./simple.cpp'])
+        self.assertExec(runner.run())
+
+        runner = tests.common.ToolRunner('view', ['--format=txt'], prefix='txt')
+        self.assertExec(runner.run())
 
     def test_std_complexity_maxindent(self):
 

--- a/metrixpp/tests/general/test_basic/test_help_collect_default_stdout.gold.txt
+++ b/metrixpp/tests/general/test_basic/test_help_collect_default_stdout.gold.txt
@@ -52,12 +52,6 @@ Options:
   --std.code.length.total, --sclent
                         Enables collection of size metric (in number of
                         symbols per region) [default: False]
-  --std.code.linelength, --scll
-                        Enables collection of maximum line-length overruns
-                        [default: False]
-  --std.code.linelength.limit=STD.CODE.LINELENGTH.LIMIT, --sclll=STD.CODE.LINELENGTH.LIMIT
-                        Modifies the limit for maximum line-length [default:
-                        80]
   --std.code.lines.code, --sclc
                         Enables collection of lines of code metric (per region
                         detalization) - number of non-empty lines of code,
@@ -74,6 +68,12 @@ Options:
                         Enables collection of total lines metric (per region
                         detalization) - number of any type of lines (blank,
                         code, comments, etc.)[default: False]
+  --std.code.longlines, --scll
+                        Enables collection of long lines metric [default:
+                        False]
+  --std.code.longlines.limit=STD.CODE.LONGLINES.LIMIT, --sclll=STD.CODE.LONGLINES.LIMIT
+                        Modifies the limit for maximum line-length [default:
+                        80]
   --std.code.magic.numbers, --scmn
                         Enables collection of magic numbers metric [default:
                         False]

--- a/metrixpp/tests/general/test_basic/test_help_collect_default_stdout.gold.txt
+++ b/metrixpp/tests/general/test_basic/test_help_collect_default_stdout.gold.txt
@@ -53,7 +53,7 @@ Options:
                         Enables collection of size metric (in number of
                         symbols per region) [default: False]
   --std.code.linelength, --scll
-                        Enables collection maximum line-length transgressions
+                        Enables collection of maximum line-length overruns
                         [default: False]
   --std.code.linelength.limit=STD.CODE.LINELENGTH.LIMIT, --sclll=STD.CODE.LINELENGTH.LIMIT
                         Modifies the limit for maximum line-length [default:

--- a/metrixpp/tests/general/test_basic/test_help_collect_default_stdout.gold.txt
+++ b/metrixpp/tests/general/test_basic/test_help_collect_default_stdout.gold.txt
@@ -52,6 +52,12 @@ Options:
   --std.code.length.total, --sclent
                         Enables collection of size metric (in number of
                         symbols per region) [default: False]
+  --std.code.linelength, --scll
+                        Enables collection maximum line-length transgressions
+                        [default: False]
+  --std.code.linelength.limit=STD.CODE.LINELENGTH.LIMIT, --sclll=STD.CODE.LINELENGTH.LIMIT
+                        Modifies the limit for maximum line-length [default:
+                        80]
   --std.code.lines.code, --sclc
                         Enables collection of lines of code metric (per region
                         detalization) - number of non-empty lines of code,

--- a/metrixpp/tests/general/test_basic/test_std_longlines_metrics_view_nest_per_file_stdout.gold.txt
+++ b/metrixpp/tests/general/test_basic/test_std_longlines_metrics_view_nest_per_file_stdout.gold.txt
@@ -1,0 +1,99 @@
+./simple.cpp:0: info: Metrics per '__global__' region
+	Region name    : __global__
+	Region type    : global
+	Offsets        : 0-697
+	Line numbers   : 1-71
+	Modified       : None
+	std.code.longlines:numbers: 0
+
+.   ./simple.cpp:4: info: Metrics per 'hmm' region
+    	Region name    : hmm
+    	Region type    : namespace
+    	Offsets        : 2-696
+    	Line numbers   : 3-70
+    	Modified       : None
+    	std.code.longlines:numbers: 0
+
+.   .   ./simple.cpp:9: info: Metrics per 'A' region
+        	Region name    : A
+        	Region type    : class
+        	Offsets        : 94-692
+        	Line numbers   : 9-68
+        	Modified       : None
+        	std.code.longlines:numbers: 0
+
+.   .   .   ./simple.cpp:12: info: Metrics per 'A' region
+            	Region name    : A
+            	Region type    : function
+            	Offsets        : 106-252
+            	Line numbers   : 12-23
+            	Modified       : None
+            	std.code.longlines:numbers: 0
+
+.   .   .   ./simple.cpp:26: info: Metrics per 'func' region
+            	Region name    : func
+            	Region type    : function
+            	Offsets        : 256-405
+            	Line numbers   : 26-40
+            	Modified       : None
+            	std.code.longlines:numbers: 0
+
+.   .   .   .   ./simple.cpp:28: info: Metrics per 'embeded' region
+                	Region name    : embeded
+                	Region type    : class
+                	Offsets        : 285-391
+                	Line numbers   : 28-38
+                	Modified       : None
+                	std.code.longlines:numbers: 0
+
+.   .   .   .   .   ./simple.cpp:30: info: Metrics per 'embeded' region
+                    	Region name    : embeded
+                    	Region type    : function
+                    	Offsets        : 306-387
+                    	Line numbers   : 30-37
+                    	Modified       : None
+                    	std.code.longlines:numbers: 0
+
+.   .   .   ./simple.cpp:42: info: Metrics per 'func_to_be_removed_in_new_sources' region
+            	Region name    : func_to_be_removed_in_new_sources
+            	Region type    : function
+            	Offsets        : 408-596
+            	Line numbers   : 42-56
+            	Modified       : None
+            	std.code.longlines:numbers: 1
+
+.   .   .   .   ./simple.cpp:44: info: Metrics per 'embeded' region
+                	Region name    : embeded
+                	Region type    : class
+                	Offsets        : 466-577
+                	Line numbers   : 44-54
+                	Modified       : None
+                	std.code.longlines:numbers: 0
+
+.   .   .   .   .   ./simple.cpp:46: info: Metrics per 'embeded' region
+                    	Region name    : embeded
+                    	Region type    : function
+                    	Offsets        : 487-573
+                    	Line numbers   : 46-53
+                    	Modified       : None
+                    	std.code.longlines:numbers: 0
+
+.   .   .   ./simple.cpp:58: info: Metrics per 'never' region
+            	Region name    : never
+            	Region type    : function
+            	Offsets        : 599-669
+            	Line numbers   : 58-65
+            	Modified       : None
+            	std.code.longlines:numbers: 0
+
+./simple.cpp:: info: Overall metrics for 'std.code.longlines:numbers' metric
+	Average        : 0.09090909
+	Minimum        : 0
+	Maximum        : 1
+	Total          : 1.0
+	Distribution   : 11 regions in total (including 0 suppressed)
+	  Metric value : Ratio : R-sum : Number of regions
+	             0 : 0.909 : 0.909 : 10	||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+	             1 : 0.091 : 1.000 :  1	|||||||||
+
+

--- a/metrixpp/tests/general/test_basic/test_std_longlines_metrics_view_txt_stdout.gold.txt
+++ b/metrixpp/tests/general/test_basic/test_std_longlines_metrics_view_txt_stdout.gold.txt
@@ -1,0 +1,15 @@
+./:: info: Overall metrics for 'std.code.longlines:numbers' metric
+	Average        : 0.0625
+	Minimum        : 0
+	Maximum        : 1
+	Total          : 1.0
+	Distribution   : 16 regions in total (including 0 suppressed)
+	  Metric value : Ratio : R-sum : Number of regions
+	             0 : 0.938 : 0.938 : 15	|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+	             1 : 0.062 : 1.000 :  1	||||||
+
+./:: info: Directory content:
+	File           : file_deleted_in_new_sources.cpp
+	File           : simple.cpp
+
+


### PR DESCRIPTION
Hi,

Here a simple plugin which collects how often the maximum allowed line length for code is overrun.
This is useful in case coding conventions specify such a maximum line length.

I still have to figure out the unit testing, but the plugin is simple enough to be verified directly.

Cheers