### PR TITLE
Enable non_zero for std.code.longlines

### DIFF
--- a/metrixpp/ext/std/code/longlines.ini
+++ b/metrixpp/ext/std/code/longlines.ini
@@ -6,7 +6,7 @@
 ;
 
 [Plugin]
-version: 1.0
+version: 1.1
 package: std.code
 module:  longlines
 class:   Plugin

--- a/metrixpp/ext/std/code/longlines.py
+++ b/metrixpp/ext/std/code/longlines.py
@@ -29,7 +29,7 @@ class Plugin(api.Plugin,
         pattern_to_search = r'''.{%s,}''' % (self.threshold + 1)
         self.declare_metric(
                 self.is_active_ll,
-                self.Field('numbers', int),
+                self.Field('numbers', int, non_zero=True),
                 re.compile(pattern_to_search),
                 marker_type_mask=api.Marker.T.CODE,
                 region_type_mask=api.Region.T.ANY,

--- a/metrixpp/tests/general/test_basic/test_std_longlines_metrics_view_nest_per_file_stdout.gold.txt
+++ b/metrixpp/tests/general/test_basic/test_std_longlines_metrics_view_nest_per_file_stdout.gold.txt
@@ -4,7 +4,6 @@
 	Offsets        : 0-788
 	Line numbers   : 1-74
 	Modified       : None
-	std.code.longlines:numbers: 0
 
 .   ./simple.cpp:4: info: Metrics per 'hmm' region
     	Region name    : hmm
@@ -12,7 +11,6 @@
     	Offsets        : 2-787
     	Line numbers   : 3-73
     	Modified       : None
-    	std.code.longlines:numbers: 0
 
 .   .   ./simple.cpp:9: info: Metrics per 'A' region
         	Region name    : A
@@ -20,7 +18,6 @@
         	Offsets        : 94-783
         	Line numbers   : 9-71
         	Modified       : None
-        	std.code.longlines:numbers: 0
 
 .   .   .   ./simple.cpp:12: info: Metrics per 'A' region
             	Region name    : A
@@ -28,7 +25,6 @@
             	Offsets        : 106-252
             	Line numbers   : 12-23
             	Modified       : None
-            	std.code.longlines:numbers: 0
 
 .   .   .   ./simple.cpp:26: info: Metrics per 'func' region
             	Region name    : func
@@ -36,7 +32,6 @@
             	Offsets        : 256-405
             	Line numbers   : 26-40
             	Modified       : None
-            	std.code.longlines:numbers: 0
 
 .   .   .   .   ./simple.cpp:28: info: Metrics per 'embeded' region
                 	Region name    : embeded
@@ -44,7 +39,6 @@
                 	Offsets        : 285-391
                 	Line numbers   : 28-38
                 	Modified       : None
-                	std.code.longlines:numbers: 0
 
 .   .   .   .   .   ./simple.cpp:30: info: Metrics per 'embeded' region
                     	Region name    : embeded
@@ -52,7 +46,6 @@
                     	Offsets        : 306-387
                     	Line numbers   : 30-37
                     	Modified       : None
-                    	std.code.longlines:numbers: 0
 
 .   .   .   ./simple.cpp:42: info: Metrics per 'func_to_be_removed_in_new_sources' region
             	Region name    : func_to_be_removed_in_new_sources
@@ -68,7 +61,6 @@
                 	Offsets        : 466-577
                 	Line numbers   : 44-54
                 	Modified       : None
-                	std.code.longlines:numbers: 0
 
 .   .   .   .   .   ./simple.cpp:46: info: Metrics per 'embeded' region
                     	Region name    : embeded
@@ -76,7 +68,6 @@
                     	Offsets        : 487-573
                     	Line numbers   : 46-53
                     	Modified       : None
-                    	std.code.longlines:numbers: 0
 
 .   .   .   ./simple.cpp:58: info: Metrics per 'never' region
             	Region name    : never
@@ -84,16 +75,14 @@
             	Offsets        : 599-669
             	Line numbers   : 58-65
             	Modified       : None
-            	std.code.longlines:numbers: 0
 
 ./simple.cpp:: info: Overall metrics for 'std.code.longlines:numbers' metric
-	Average        : 0.09090909
-	Minimum        : 0
+	Average        : 1.0 (excluding zero metric values)
+	Minimum        : 1
 	Maximum        : 1
 	Total          : 1.0
-	Distribution   : 11 regions in total (including 0 suppressed)
+	Distribution   : 1 regions in total (including 0 suppressed)
 	  Metric value : Ratio : R-sum : Number of regions
-	             0 : 0.909 : 0.909 : 10	||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-	             1 : 0.091 : 1.000 :  1	|||||||||
+	             1 : 1.000 : 1.000 : 1	||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 
 

--- a/metrixpp/tests/general/test_basic/test_std_longlines_metrics_view_txt_stdout.gold.txt
+++ b/metrixpp/tests/general/test_basic/test_std_longlines_metrics_view_txt_stdout.gold.txt
@@ -1,12 +1,11 @@
 ./:: info: Overall metrics for 'std.code.longlines:numbers' metric
-	Average        : 0.0625
-	Minimum        : 0
+	Average        : 1.0 (excluding zero metric values)
+	Minimum        : 1
 	Maximum        : 1
 	Total          : 1.0
-	Distribution   : 16 regions in total (including 0 suppressed)
+	Distribution   : 1 regions in total (including 0 suppressed)
 	  Metric value : Ratio : R-sum : Number of regions
-	             0 : 0.938 : 0.938 : 15	|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-	             1 : 0.062 : 1.000 :  1	||||||
+	             1 : 1.000 : 1.000 : 1	||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 
 ./:: info: Directory content:
 	File           : file_deleted_in_new_sources.cpp


### PR DESCRIPTION
In the first version i forgot to enable **non_zero** for the new plugin, now counting should behave as the magic numbers plugin